### PR TITLE
apk-validate: Better input escaping and error checking.

### DIFF
--- a/apk/apk-validate
+++ b/apk/apk-validate
@@ -14,6 +14,7 @@
 #              -keystore /path/to/keystore \
 #              -storepass keystore-password \
 #              -alias name-of-key-in-store
+#              -certfile path-to-certfile (optional, defaults to META-INF/CERT.RSA)
 #
 # For example - to validate against your debug key
 # example: apk-validate -apk my.apk \
@@ -30,31 +31,35 @@ function apk-validate() {
     local alias=
     local keysig=
     local apksig=
+    local certfile='META-INF/CERT.RSA'
+    set +o nounset
     while [ -n "$1" ]; do
-        case $1 in
-        -apk) shift; apk=$1 ;;
-        -keystore) shift; keystore=$1 ;;
-        -storepass) shift; storepass=$1 ;;
-        -alias) shift; alias=$1 ;;
+        case "$1" in
+        -apk) shift; apk="$1" ;;
+        -keystore) shift; keystore="$1" ;;
+        -storepass) shift; storepass="$1" ;;
+        -alias) shift; alias="$1" ;;
+        -certfile) shift; certfile="$1" ;;
         *)
-            echo >&2 $0: unknown parameter $1
+            echo >&2 "$0: unknown parameter $1"
             return 1
         esac
         shift
     done
+    set -o nounset
     if [ -z "$apk" -o -z "$keystore" -o -z "$storepass" -o -z "$alias" ]; then
         echo >&2 "usage: $FUNCNAME -apk apk -keystore keystore -storepass storepass -alias alias"
         echo >&2 "See the man page for keytool for an explanation of the parameters."
         return 1
     fi
     # Validate the apk has not been tampered with
-    jarsigner -verify $apk >/dev/null || {
+    jarsigner -verify "$apk" >/dev/null || {
         echo >&2 "$FUNCNAME: error in jarsigner -verify $apk"
         return 1
     }
     # Validate the apk is signed with the key we think it is
-    keysig="$(keytool -list -v -keystore $keystore -alias $alias -storepass $storepass | sed -n '/SHA1: /s/.*: //p')"
-    apksig="$(unzip -p $apk META-INF/CERT.RSA | keytool -printcert | sed -n '/SHA1:/s/.*: //p')"
+    keysig="$(keytool -list -v -keystore "$keystore" -alias "$alias" -storepass "$storepass" | sed -n '/SHA1: /s/.*: //p')"
+    apksig="$(unzip -p "$apk" "$certfile" | keytool -printcert | sed -n '/SHA1:/s/.*: //p')"
     if [ -z "$keysig" -o -z "$apksig" -o "$keysig" != "$apksig" ]; then
         echo >&2 "$FUNCNAME: Signatures do not match"
         echo >&2 "  key sig: $keysig"

--- a/apk/apk-validate.sh
+++ b/apk/apk-validate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+######################################################################
+# Command-line interface for apk-validate function
+# See comments in apk-validate file for documentation
+######################################################################
+# (c) Eliot Lash 2016 - Apache license 2.0
+######################################################################
+set -o pipefail
+set -o nounset
+
+source apk-validate
+
+apk-validate "$@"


### PR DESCRIPTION
Add parameter for specifying cert file path and command-line interface script.
